### PR TITLE
fix: cache for python venv

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7.11, 3.8.12, 3.9.6]
 
     services:
       redis:


### PR DESCRIPTION
Python's venv caching may not work if minor version number is not specified in versions matrix.